### PR TITLE
Workaround for the missing arp binary in /usr/sbin

### DIFF
--- a/stemcell_builder/stages/base_opensuse/apply.sh
+++ b/stemcell_builder/stages/base_opensuse/apply.sh
@@ -46,6 +46,9 @@ rm /etc/hosts.equiv
 
 # Explicitly enable zypper's gpgcheck
 echo 'gpgcheck = on' >> /etc/zypp/zypp.conf
+
+# Ensure compatibility to the ubuntu stack, where arp resides in /usr/sbin
+ln -s /sbin/arp /usr/sbin/arp
 "
 
 touch ${chroot}/etc/gshadow


### PR DESCRIPTION
This PR adds compatibility for the opensuse stack.
The arp binary resides in /sbin instead of /usr/sbin there.