### PR TITLE
validate.patch needs to be copied into the destination path as well

### DIFF
--- a/stemcell_builder/stages/bosh_monit/apply.sh
+++ b/stemcell_builder/stages/bosh_monit/apply.sh
@@ -11,6 +11,7 @@ monit_archive=$monit_basename.tar.gz
 
 mkdir -p $chroot/$bosh_dir/src
 cp -r $dir/assets/$monit_archive $chroot/$bosh_dir/src
+cp -r $dir/assets/validate.patch $chroot/$bosh_dir/src
 
 run_in_bosh_chroot $chroot "
 cd src


### PR DESCRIPTION
The patch command is being run inside a chroot, so we can't reference it with the full path from the original location.

[trello#gJ5tA8S4]