### PR TITLE
Use a date format that allows rotating logs multiple times per day

### DIFF
--- a/stemcell_builder/stages/logrotate_config/assets/opensuse-logrotate.conf
+++ b/stemcell_builder/stages/logrotate_config/assets/opensuse-logrotate.conf
@@ -15,6 +15,9 @@ create
 # use date as a suffix of the rotated file
 dateext
 
+# Use a dateformat that lets us rotate multiple times per day
+dateformat -%Y%m%d-%s
+
 # uncomment this if you want your log files compressed
 #compress
 


### PR DESCRIPTION
otherwise we get and error that the "rotation" file already exists